### PR TITLE
Added check for updates option

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2026.06.10-dev</Version>
+    <Version>2026.06.10.2</Version>
     <Company>vov4uk</Company>
     <Copyright>Copyright (C) vov4uk</Copyright>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="NLog" Version="6.1.3" />
     <PackageVersion Include="Onova" Version="2.6.13" />
     <PackageVersion Include="Prism.Core" Version="9.0.537" />
-    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.26.0.140279" />
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.27.0.140913" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.1" />
     <PackageVersion Include="Tabula" Version="1.0.1" />
     <PackageVersion Include="ToastNotifications.Messages.Net5" Version="3.0.1" />

--- a/src/Financier.Desktop/Data/SettingsDTO.cs
+++ b/src/Financier.Desktop/Data/SettingsDTO.cs
@@ -4,14 +4,37 @@ namespace Financier.Desktop.Data
 {
     public class SettingsDTO : BindableBase
     {
+        public SettingsGeneralDTO General { get; set; } = new SettingsGeneralDTO();
+        public SettingsExchangeRates ExchangeRates { get; set; } = new SettingsExchangeRates();
+    }
 
+    public class SettingsGeneralDTO : BindableBase
+    {
+        private bool checkForUpdatesOnStart;
+
+        public bool CheckForUpdatesOnStart
+        {
+            get => checkForUpdatesOnStart;
+            set
+            {
+                if (checkForUpdatesOnStart != value)
+                {
+                    checkForUpdatesOnStart = value;
+                    RaisePropertyChanged(nameof(CheckForUpdatesOnStart));
+                }
+            }
+        }
+    }
+
+    public class SettingsExchangeRates: BindableBase
+    {
         private string exchangeRatesProvider;
         private string openExchangeRatesProviderAppId;
-        private bool updateExchangeRatesOnStart;
+        private bool updateOnStart;
 
-        public bool IsAutoUpdateEnabled { get; init; }
 
-        public string ExchangeRatesProvider
+
+        public string Provider
         {
             get => exchangeRatesProvider;
             set
@@ -19,7 +42,7 @@ namespace Financier.Desktop.Data
                 if (exchangeRatesProvider != value)
                 {
                     exchangeRatesProvider = value;
-                    RaisePropertyChanged(nameof(ExchangeRatesProvider));
+                    RaisePropertyChanged(nameof(Provider));
                 }
             }
         }
@@ -36,15 +59,15 @@ namespace Financier.Desktop.Data
             }
         }
 
-        public bool UpdateExchangeRatesOnStart
+        public bool UpdateOnStart
         {
-            get => updateExchangeRatesOnStart;
+            get => updateOnStart;
             set
             {
-                if (updateExchangeRatesOnStart != value)
+                if (updateOnStart != value)
                 {
-                    updateExchangeRatesOnStart = value;
-                    RaisePropertyChanged(nameof(UpdateExchangeRatesOnStart));
+                    updateOnStart = value;
+                    RaisePropertyChanged(nameof(UpdateOnStart));
                 }
             }
         }

--- a/src/Financier.Desktop/Helpers/DialogHelper.cs
+++ b/src/Financier.Desktop/Helpers/DialogHelper.cs
@@ -91,12 +91,12 @@ namespace Financier.Desktop.Helpers
         {
             if (yesNoButtons)
             {
-                var result = System.Windows.Forms.MessageBox.Show(text, caption, MessageBoxButtons.YesNo);
-                return result == DialogResult.Yes;
+                var result = System.Windows.MessageBox.Show(text, caption, MessageBoxButton.YesNo);
+                return result == MessageBoxResult.Yes;
             }
             else
             {
-                System.Windows.Forms.MessageBox.Show(text, caption);
+                System.Windows.MessageBox.Show(text, caption);
                 return true;
             }
         }

--- a/src/Financier.Desktop/MainWindow.xaml
+++ b/src/Financier.Desktop/MainWindow.xaml
@@ -9,6 +9,7 @@
                xmlns:View="clr-namespace:Financier.Desktop.Views"
                xmlns:Wizard="clr-namespace:Financier.Desktop.Wizards"
                xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+               xmlns:s="clr-namespace:System;assembly=mscorlib"
                AllowDrop="True"
                Loaded="RibbonWindow_Loaded">
     <Window.Resources>
@@ -53,6 +54,7 @@
             <x:Type x:Key="TransactionsViewType" TypeName="data:BlotterModel" />
             <x:Type x:Key="ReportsControl" TypeName="reports:ReportsControlVM" />
             <x:Type x:Key="RulesType" TypeName="data:RuleModel" />
+            <s:Boolean x:Key="True">True</s:Boolean>
             <converters:StringEmptyToVisibilityConverter x:Key="StringToVisibilityConverter" />
             <BooleanToVisibilityConverter x:Key="BoolToVis" />
             <converters:InverseBooleanConverter x:Key="InverseBool" />
@@ -349,6 +351,13 @@
                     <RibbonButton LargeImageSource="{StaticResource ResourceKey=IconDownload}"
                                   Label="Download"
                                   Command="{Binding Path=RefreshExchangeRatesCommand}" />
+                </RibbonGroup>
+                <RibbonGroup Header="General"
+                         DataContext="{Binding}">
+                    <RibbonButton LargeImageSource="{StaticResource ResourceKey=IconRefresh}"
+                              Label="Check for Updates"
+                              Command="{Binding Path=CheckForUpdateCommand}"
+                              CommandParameter="{StaticResource True}" />
                 </RibbonGroup>
             </RibbonTab>
         </Ribbon>

--- a/src/Financier.Desktop/MainWindow.xaml.cs
+++ b/src/Financier.Desktop/MainWindow.xaml.cs
@@ -44,7 +44,7 @@ namespace Financier.Desktop
             Logger.Info("App started");
         }
 
-        private void RibbonWindow_Loaded(object sender, RoutedEventArgs e)
+        private async void RibbonWindow_Loaded(object sender, RoutedEventArgs e)
         {
             var bakupFolder = Settings.Default.DefaultBackupDir ?? @$"C:\Users\{Environment.UserName}\Dropbox\apps\Financisto Holo";
             ViewModel.DefaultBackupDirectory = Settings.Default.DefaultBackupDir;
@@ -55,12 +55,9 @@ namespace Financier.Desktop
                 if (!string.IsNullOrEmpty(backupFile) && File.Exists(backupFile))
                 {
                     Logger.Info($"Loaded backup : {backupFile}");
-                    Task.Run(() => ViewModel.OpenBackup(backupFile))
-                        .ContinueWith((t) =>
-                        {
-                            ViewModel.RefreshExchangeRatesCommand.ExecuteAsync();
-                            ViewModel.CheckForUpdateCommand.ExecuteAsync(false);
-                        });
+                    await Task.Run(() => ViewModel.OpenBackup(backupFile));
+                    await ViewModel.RefreshExchangeRatesCommand.ExecuteAsync();
+                    await ViewModel.CheckForUpdateCommand.ExecuteAsync(false);
                 }
             }
         }

--- a/src/Financier.Desktop/MainWindow.xaml.cs
+++ b/src/Financier.Desktop/MainWindow.xaml.cs
@@ -36,7 +36,7 @@ namespace Financier.Desktop
         public MainWindow()
         {
             InitializeComponent();
-            ViewModel = new MainWindowVM(new DialogHelper(), new FinancierDatabaseFactory(), new EntityReader(), new BackupWriter(), new ToastNotifierWrapper(), new BankHelperFactory(), new Services.UpdateService(new Data.SettingsDTO { IsAutoUpdateEnabled = true}));
+            ViewModel = new MainWindowVM(new DialogHelper(), new FinancierDatabaseFactory(), new EntityReader(), new BackupWriter(), new ToastNotifierWrapper(), new BankHelperFactory(), new Services.UpdateService());
 
             DataContext = ViewModel;
             var version = Assembly.GetExecutingAssembly().GetName().Version;
@@ -48,7 +48,7 @@ namespace Financier.Desktop
         {
             var bakupFolder = Settings.Default.DefaultBackupDir ?? @$"C:\Users\{Environment.UserName}\Dropbox\apps\Financisto Holo";
             ViewModel.DefaultBackupDirectory = Settings.Default.DefaultBackupDir;
-            ViewModel.ExchangeRatesSettings = Settings.Default.ExchangeRatesSettings;
+            ViewModel.AppSettings = Settings.Default.AppSettings;
             if (Directory.Exists(bakupFolder))
             {
                 var backupFile = Directory.EnumerateFiles(bakupFolder, BackupFormat).OrderByDescending(x => x).FirstOrDefault();
@@ -56,7 +56,11 @@ namespace Financier.Desktop
                 {
                     Logger.Info($"Loaded backup : {backupFile}");
                     Task.Run(() => ViewModel.OpenBackup(backupFile))
-                        .ContinueWith((t) => ViewModel.RefreshExchangeRatesCommand.ExecuteAsync());
+                        .ContinueWith((t) =>
+                        {
+                            ViewModel.RefreshExchangeRatesCommand.ExecuteAsync();
+                            ViewModel.CheckForUpdateCommand.ExecuteAsync(false);
+                        });
                 }
             }
         }

--- a/src/Financier.Desktop/MainWindowVM.cs
+++ b/src/Financier.Desktop/MainWindowVM.cs
@@ -474,7 +474,7 @@ namespace Financier.Desktop.ViewModel
                 var jObj = JObject.FromObject(updated);
                 if (!string.IsNullOrEmpty(updated.ExchangeRates.OpenExchangeRatesProviderAppId))
                 {
-                    jObj[nameof(SettingsDTO.ExchangeRates.OpenExchangeRatesProviderAppId)] =
+                    jObj[nameof(SettingsDTO.ExchangeRates)][nameof(SettingsExchangeRates.OpenExchangeRatesProviderAppId)] =
                         SettingsProtection.Encrypt(updated.ExchangeRates.OpenExchangeRatesProviderAppId);
                 }
                 string json = jObj.ToString(Formatting.Indented);
@@ -555,6 +555,12 @@ namespace Financier.Desktop.ViewModel
                 {
                     var dto = JsonConvert.DeserializeObject<SettingsDTO>(json);
 
+                    if (dto.ExchangeRates == null)
+                        dto.ExchangeRates = new SettingsExchangeRates();
+
+                    if (dto.General == null)
+                        dto.General = new SettingsGeneralDTO();
+
                     if (!string.IsNullOrEmpty(dto.ExchangeRates?.OpenExchangeRatesProviderAppId))
                     {
                         dto.ExchangeRates.OpenExchangeRatesProviderAppId =
@@ -597,7 +603,10 @@ namespace Financier.Desktop.ViewModel
 
                 var settings = TryDeserializeSettings(AppSettings);
 
-                var updateVersion = await updateService.CheckForUpdatesAsync(settings.General);
+                if (!settings.General.CheckForUpdatesOnStart || !showMessageIfLatest)
+                    return;
+
+                var updateVersion = await updateService.CheckForUpdatesAsync();
                 if (updateVersion is null)
                 {
                     if (showMessageIfLatest)
@@ -620,12 +629,12 @@ namespace Financier.Desktop.ViewModel
                         "Financier.Desktop",
                         updateVersion));
 
-                    await updateService.PrepareUpdateAsync(updateVersion, settings.General);
+                    await updateService.PrepareUpdateAsync(updateVersion);
 
                     notifier.ShowMessage("Update is downloaded. App will now restart to apply the update.");
-                    Task.Delay(3000).Wait();
-                    updateService.FinalizeUpdate(true, settings.General);
-                    Task.Delay(3000).Wait();
+                    await Task.Delay(3000);
+                    updateService.FinalizeUpdate(true);
+                    await Task.Delay(3000);
                     Environment.Exit(0);
                 }
             }

--- a/src/Financier.Desktop/MainWindowVM.cs
+++ b/src/Financier.Desktop/MainWindowVM.cs
@@ -53,7 +53,7 @@ namespace Financier.Desktop.ViewModel
         private IAsyncCommand _saveBackupAsDbCommand;
         private IAsyncCommand _settingsCommand;
         private IAsyncCommand _refreshExchangeRatesCommand;
-        private IAsyncCommand _checkForUpdateCommand;
+        private IAsyncCommand<bool> _checkForUpdateCommand;
         private readonly IBackupWriter backupWriter;
         private BlotterVM blotterVm;
         private BindableBase currentPage;
@@ -134,7 +134,7 @@ namespace Financier.Desktop.ViewModel
             internal set => SetProperty(ref defaultBackupDirectory, value);
         }
 
-        public string ExchangeRatesSettings
+        public string AppSettings
         {
             get => exchangeRatesSettings;
             internal set => SetProperty(ref exchangeRatesSettings, value);
@@ -182,7 +182,7 @@ namespace Financier.Desktop.ViewModel
 
         public IAsyncCommand SettingsCommand => _settingsCommand ??= new AsyncCommand(Settings_Click);
         public IAsyncCommand RefreshExchangeRatesCommand => _refreshExchangeRatesCommand ??= new AsyncCommand(RefreshExchangeRates_Click);
-        public IAsyncCommand CheckForUpdateCommand => _checkForUpdateCommand ??= new AsyncCommand(CheckForUpdatesAsync);
+        public IAsyncCommand<bool> CheckForUpdateCommand => _checkForUpdateCommand ??= new AsyncCommand<bool>(CheckForUpdatesAsync);
 
         public async Task OpenBackup(string backupPath)
         {
@@ -464,58 +464,46 @@ namespace Financier.Desktop.ViewModel
 
         private async Task Settings_Click()
         {
-            SettingsDTO dto = null;
-            if (string.IsNullOrEmpty(ExchangeRatesSettings))
-            {
-                dto = new SettingsDTO()
-                {
-                    ExchangeRatesProvider = string.Empty,
-                    UpdateExchangeRatesOnStart = false,
-                };
-            }
-            else
-            {
-                dto = TryDeserializeSettings(ExchangeRatesSettings);
-            }
+            SettingsDTO settings = TryDeserializeSettings(AppSettings);
 
-            DialogBaseVM vm = new SettingsVM(dto);
+            DialogBaseVM vm = new SettingsVM(settings);
             var updated = dialogWrapper.ShowDialog<SettingsControl>(vm, 300, 400, "Settings") as SettingsDTO;
 
             if (updated != null)
             {
                 var jObj = JObject.FromObject(updated);
-                if (!string.IsNullOrEmpty(updated.OpenExchangeRatesProviderAppId))
+                if (!string.IsNullOrEmpty(updated.ExchangeRates.OpenExchangeRatesProviderAppId))
                 {
-                    jObj[nameof(SettingsDTO.OpenExchangeRatesProviderAppId)] =
-                        SettingsProtection.Encrypt(updated.OpenExchangeRatesProviderAppId);
+                    jObj[nameof(SettingsDTO.ExchangeRates.OpenExchangeRatesProviderAppId)] =
+                        SettingsProtection.Encrypt(updated.ExchangeRates.OpenExchangeRatesProviderAppId);
                 }
                 string json = jObj.ToString(Formatting.Indented);
-                Settings.Default.ExchangeRatesSettings = json;
+                Settings.Default.AppSettings = json;
                 Settings.Default.Save();
-                ExchangeRatesSettings = json;
+                AppSettings = json;
             }
         }
 
         private async Task RefreshExchangeRates_Click()
         {
-            if (!string.IsNullOrEmpty(ExchangeRatesSettings))
+            if (!string.IsNullOrEmpty(AppSettings))
             {
-                var dto = TryDeserializeSettings(ExchangeRatesSettings);
+                var settings = TryDeserializeSettings(AppSettings);
 
-                if (dto.UpdateExchangeRatesOnStart)
+                if (settings.ExchangeRates.UpdateOnStart)
                 {
                     var exchangeRateLoader = new ExchangeRateLoader();
                     List<CurrencyExchangeRate> exchangeRates = new List<CurrencyExchangeRate>();
 
-                    if (dto.ExchangeRatesProvider == "freecurrencyrates.com")
+                    if (settings.ExchangeRates.Provider == "freecurrencyrates.com")
                     {
                         exchangeRates = await exchangeRateLoader.LoadFreeCurrencyRates();
                     }
-                    else if (dto.ExchangeRatesProvider == "openexchangerates.org")
+                    else if (settings.ExchangeRates.Provider == "openexchangerates.org")
                     {
-                        exchangeRates = await exchangeRateLoader.LoadOpenExchangeRates(dto.OpenExchangeRatesProviderAppId);
+                        exchangeRates = await exchangeRateLoader.LoadOpenExchangeRates(settings.ExchangeRates.OpenExchangeRatesProviderAppId);
                     }
-                    else if (dto.ExchangeRatesProvider == "monobank.ua")
+                    else if (settings.ExchangeRates.Provider == "monobank.ua")
                     {
                         exchangeRates = await exchangeRateLoader.LoadMonobankRates();
                     }
@@ -549,7 +537,7 @@ namespace Financier.Desktop.ViewModel
                             return;
                         }
 
-                        notifier?.ShowMessage($"Exchange rates updated successfully from {dto.ExchangeRatesProvider}.");
+                        notifier?.ShowMessage($"Exchange rates updated successfully from {settings.ExchangeRates.Provider}.");
                     }
                 }
             }
@@ -561,61 +549,89 @@ namespace Financier.Desktop.ViewModel
 
         private SettingsDTO TryDeserializeSettings(string json)
         {
-            try
+            if (!string.IsNullOrEmpty(json))
             {
-                var dto = JsonConvert.DeserializeObject<SettingsDTO>(json)
-                    ?? new SettingsDTO { ExchangeRatesProvider = string.Empty, UpdateExchangeRatesOnStart = false };
-
-                if (!string.IsNullOrEmpty(dto.OpenExchangeRatesProviderAppId))
+                try
                 {
-                    dto.OpenExchangeRatesProviderAppId =
-                        SettingsProtection.TryDecrypt(dto.OpenExchangeRatesProviderAppId);
-                }
+                    var dto = JsonConvert.DeserializeObject<SettingsDTO>(json);
 
-                return dto;
+                    if (!string.IsNullOrEmpty(dto.ExchangeRates?.OpenExchangeRatesProviderAppId))
+                    {
+                        dto.ExchangeRates.OpenExchangeRatesProviderAppId =
+                            SettingsProtection.TryDecrypt(dto.ExchangeRates.OpenExchangeRatesProviderAppId);
+                    }
+
+                    return dto;
+                }
+                catch (Exception ex)
+                {
+                    Logger.Warn(ex, "Failed to deserialize AppSettings; resetting to defaults.");
+                    AppSettings = null;
+                    Settings.Default.AppSettings = null;
+                    Settings.Default.Save();
+                    notifier?.ShowWarning("Settings file was corrupted and has been reset. Please re-configure exchange rate settings.");
+
+                }
             }
-            catch (JsonException ex)
+
+            return new SettingsDTO()
             {
-                Logger.Warn(ex, "Failed to deserialize ExchangeRatesSettings; resetting to defaults.");
-                ExchangeRatesSettings = null;
-                Settings.Default.ExchangeRatesSettings = null;
-                Settings.Default.Save();
-                notifier?.ShowWarning("Settings file was corrupted and has been reset. Please re-configure exchange rate settings.");
-                return new SettingsDTO { ExchangeRatesProvider = string.Empty, UpdateExchangeRatesOnStart = false };
-            }
+                ExchangeRates = new SettingsExchangeRates
+                {
+                    Provider = string.Empty,
+                    UpdateOnStart = false,
+                },
+                General = new SettingsGeneralDTO
+                {
+                    CheckForUpdatesOnStart = true
+                }
+            };
         }
 
-        private async Task CheckForUpdatesAsync()
+        private async Task CheckForUpdatesAsync(bool showMessageIfLatest = true)
         {
             try
             {
                 if(updateService == null)
                     return;
 
-                var updateVersion = await updateService.CheckForUpdatesAsync();
+                var settings = TryDeserializeSettings(AppSettings);
+
+                var updateVersion = await updateService.CheckForUpdatesAsync(settings.General);
                 if (updateVersion is null)
+                {
+                    if (showMessageIfLatest)
+                    {
+                        notifier.ShowMessage("You are using the latest version.");
+                    }
                     return;
+                }
 
-                notifier.ShowMessage(
-                    string.Format(
-                        "Downloading update to {0} v{1}...",
+
+                var result = dialogWrapper.ShowMessageBox(
+                   "Would you like to restart app and apply the update?",
+                   $"Version {updateVersion} is available",
+                    true);
+
+                if (result)
+                {
+
+                    notifier.ShowMessage(string.Format("Downloading update to {0} v{1}...",
                         "Financier.Desktop",
-                        updateVersion
-                    )
-                );
-                await updateService.PrepareUpdateAsync(updateVersion);
+                        updateVersion));
 
-                notifier.ShowMessage(
-                    "Update has been downloaded and will be installed when you exit");
+                    await updateService.PrepareUpdateAsync(updateVersion, settings.General);
 
-                updateService.FinalizeUpdate(true);
-
-                Application.Current.Shutdown();
-
+                    notifier.ShowMessage("Update is downloaded. App will now restart to apply the update.");
+                    Task.Delay(3000).Wait();
+                    updateService.FinalizeUpdate(true, settings.General);
+                    Task.Delay(3000).Wait();
+                    Environment.Exit(0);
+                }
             }
-            catch
+            catch (Exception ex)
             {
-                // Failure to update shouldn't crash the application
+                Logger.Error(ex, "Failed to perform application update");
                 notifier.ShowWarning("Failed to perform application update");
             }
         }

--- a/src/Financier.Desktop/Pages/Dialogs/SettingsControl.xaml
+++ b/src/Financier.Desktop/Pages/Dialogs/SettingsControl.xaml
@@ -18,6 +18,13 @@
         <TabControl TabStripPlacement="Left" 
                     Margin="0, 0, 0, 10"
                     Grid.Row="0">
+            <TabItem Name="general" Header="General" IsSelected="True">
+                <TabItem.Content>
+                    <StackPanel Margin="5">
+                        <CheckBox Margin="5" Content="Check for updates on start?" IsChecked="{Binding Entity.General.CheckForUpdatesOnStart, Mode=TwoWay}"/>
+                    </StackPanel>
+                </TabItem.Content>
+            </TabItem>
             <TabItem Name="fontweight" Header="Exchange rates">
                 <TabItem.Content>
                     <Grid>
@@ -38,11 +45,11 @@
                                   Margin="5"
                                   Header="App id"
                                   Visibility="{Binding IsOpenExchangeRatesProviderSelected, Converter={StaticResource BoolToVis}, UpdateSourceTrigger=PropertyChanged}">
-                            <TextBox Margin="5" Text="{Binding Entity.OpenExchangeRatesProviderAppId, Mode=TwoWay}"
+                            <TextBox Margin="5" Text="{Binding Entity.ExchangeRates.OpenExchangeRatesProviderAppId, Mode=TwoWay}"
                                      />
                         </GroupBox>
                         <CheckBox Grid.Row="2" Grid.Column="0" Margin="5" Content="Update exchange rates on start?"
-                                  IsChecked="{Binding Entity.UpdateExchangeRatesOnStart, Mode=TwoWay}"/>
+                                  IsChecked="{Binding Entity.ExchangeRates.UpdateOnStart, Mode=TwoWay}"/>
                     </Grid>
                 </TabItem.Content>
             </TabItem>

--- a/src/Financier.Desktop/Pages/Dialogs/SettingsVM.cs
+++ b/src/Financier.Desktop/Pages/Dialogs/SettingsVM.cs
@@ -50,9 +50,9 @@ namespace Financier.Desktop.Pages.Dialogs
         public SettingsVM(SettingsDTO entity)
         {
             this.Entity = entity;
-            this.IsOpenExchangeRatesProviderSelected = entity.ExchangeRatesProvider == "openexchangerates.org";
-            this.IsFreeCurrencyRatesProviderSelected = entity.ExchangeRatesProvider == "freecurrencyrates.com";
-            this.IsMonobankProviderSelected = entity.ExchangeRatesProvider == "monobank.ua";
+            this.IsOpenExchangeRatesProviderSelected = entity.ExchangeRates.Provider == "openexchangerates.org";
+            this.IsFreeCurrencyRatesProviderSelected = entity.ExchangeRates.Provider == "freecurrencyrates.com";
+            this.IsMonobankProviderSelected = entity.ExchangeRates.Provider == "monobank.ua";
         }
 
         public SettingsDTO Entity { get; }
@@ -61,17 +61,17 @@ namespace Financier.Desktop.Pages.Dialogs
         {
             if (IsOpenExchangeRatesProviderSelected)
             {
-                Entity.ExchangeRatesProvider = "openexchangerates.org";
+                Entity.ExchangeRates.Provider = "openexchangerates.org";
             }
             else if (IsFreeCurrencyRatesProviderSelected)
             {
-                Entity.ExchangeRatesProvider = "freecurrencyrates.com";
-                Entity.OpenExchangeRatesProviderAppId = "";
+                Entity.ExchangeRates.Provider = "freecurrencyrates.com";
+                Entity.ExchangeRates.OpenExchangeRatesProviderAppId = "";
             }
             else if(IsMonobankProviderSelected)
             {
-                Entity.ExchangeRatesProvider = "monobank.ua";
-                Entity.OpenExchangeRatesProviderAppId = "";
+                Entity.ExchangeRates.Provider = "monobank.ua";
+                Entity.ExchangeRates.OpenExchangeRatesProviderAppId = "";
             }
             return Entity;
         }

--- a/src/Financier.Desktop/Properties/Settings.Designer.cs
+++ b/src/Financier.Desktop/Properties/Settings.Designer.cs
@@ -20,10 +20,10 @@ namespace Financier.Desktop.Properties
         }
 
         [UserScopedSetting]
-        public string ExchangeRatesSettings
+        public string AppSettings
         {
-            get => (string)this[nameof(ExchangeRatesSettings)];
-            set => this[nameof(ExchangeRatesSettings)] = (object)value;
+            get => (string)this[nameof(AppSettings)];
+            set => this[nameof(AppSettings)] = (object)value;
         }
     }
 }

--- a/src/Financier.Desktop/Services/UpdateService.cs
+++ b/src/Financier.Desktop/Services/UpdateService.cs
@@ -8,7 +8,7 @@ using Onova.Services;
 
 namespace Financier.Desktop.Services
 {
-    public class UpdateService(SettingsDTO settingsService) : IDisposable
+    public class UpdateService() : IDisposable
     {
         private readonly IUpdateManager? _updateManager = new UpdateManager(
                     new GithubPackageResolver(
@@ -23,24 +23,24 @@ namespace Financier.Desktop.Services
         private bool _isUpdatePrepared;
         private bool _isUpdaterLaunched;
 
-        public async Task<Version?> CheckForUpdatesAsync()
+        public async Task<Version?> CheckForUpdatesAsync(SettingsGeneralDTO settingsService)
         {
             if (_updateManager is null)
                 return null;
 
-            if (!settingsService.IsAutoUpdateEnabled)
+            if (!settingsService.CheckForUpdatesOnStart)
                 return null;
 
             var check = await _updateManager.CheckForUpdatesAsync();
             return check.CanUpdate ? check.LastVersion : null;
         }
 
-        public async Task PrepareUpdateAsync(Version version)
+        public async Task PrepareUpdateAsync(Version version, SettingsGeneralDTO settingsService)
         {
             if (_updateManager is null)
                 return;
 
-            if (!settingsService.IsAutoUpdateEnabled)
+            if (!settingsService.CheckForUpdatesOnStart)
                 return;
 
             try
@@ -58,12 +58,12 @@ namespace Financier.Desktop.Services
             }
         }
 
-        public void FinalizeUpdate(bool needRestart)
+        public void FinalizeUpdate(bool needRestart, SettingsGeneralDTO settingsService)
         {
             if (_updateManager is null)
                 return;
 
-            if (!settingsService.IsAutoUpdateEnabled)
+            if (!settingsService.CheckForUpdatesOnStart)
                 return;
 
             if (_updateVersion is null || !_isUpdatePrepared || _isUpdaterLaunched)

--- a/src/Financier.Desktop/Services/UpdateService.cs
+++ b/src/Financier.Desktop/Services/UpdateService.cs
@@ -23,24 +23,18 @@ namespace Financier.Desktop.Services
         private bool _isUpdatePrepared;
         private bool _isUpdaterLaunched;
 
-        public async Task<Version?> CheckForUpdatesAsync(SettingsGeneralDTO settingsService)
+        public async Task<Version?> CheckForUpdatesAsync()
         {
             if (_updateManager is null)
-                return null;
-
-            if (!settingsService.CheckForUpdatesOnStart)
                 return null;
 
             var check = await _updateManager.CheckForUpdatesAsync();
             return check.CanUpdate ? check.LastVersion : null;
         }
 
-        public async Task PrepareUpdateAsync(Version version, SettingsGeneralDTO settingsService)
+        public async Task PrepareUpdateAsync(Version version)
         {
             if (_updateManager is null)
-                return;
-
-            if (!settingsService.CheckForUpdatesOnStart)
                 return;
 
             try
@@ -58,12 +52,9 @@ namespace Financier.Desktop.Services
             }
         }
 
-        public void FinalizeUpdate(bool needRestart, SettingsGeneralDTO settingsService)
+        public void FinalizeUpdate(bool needRestart)
         {
             if (_updateManager is null)
-                return;
-
-            if (!settingsService.CheckForUpdatesOnStart)
                 return;
 
             if (_updateVersion is null || !_isUpdatePrepared || _isUpdaterLaunched)


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Add “check for updates on start” setting and manual update trigger
<code>✨ Enhancement</code> <code>⚙️ Configuration changes</code> <code>🕐 20-40 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>Description</summary>

<br/>

<pre>
• Add a General settings section with “check for updates on start” toggle.
• Refactor app settings JSON to group General and Exchange Rates settings.
• Add a ribbon button to manually check for updates and optionally restart to apply.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A(["MainWindow Loaded"]) --> B(["MainWindowVM"]) --> C(["UpdateService"]) --> D{{"GitHub Releases"}}
  B --> E[("AppSettings JSON")]
  F(["Settings Dialog"]) --> E
  
  subgraph Legend
    direction LR
    _ui(["UI/ViewModel"]) ~~~ _store[("Stored settings")] ~~~ _ext{{"External"}}
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Decouple manual update checks from the startup flag</b></summary>

- ➕ User can always run “Check for Updates” even if startup checks are disabled
- ➕ Cleaner semantics: startup automation toggle doesn’t block explicit user actions
- ➖ Requires separating ‘allow updates’ vs ‘auto-check on start’ in API/design
- ➖ May need small UI copy changes to clarify behavior

</details>

<details>
<summary><b>2. Introduce settings versioning / migration for the JSON schema</b></summary>

- ➕ Safer evolution from the old flat ExchangeRates settings to nested objects
- ➕ Reduces risk of settings loss/reset on deserialization edge cases
- ➖ More code and long-term maintenance (migration paths)
- ➖ Needs additional test coverage for upgrades/downgrades

</details>

<details>
<summary><b>3. Use non-blocking restart flow (avoid synchronous waits)</b></summary>

- ➕ Prevents UI thread blocking and avoids potential deadlocks/freezes
- ➕ More predictable shutdown/restart behavior
- ➖ Slightly more complex async orchestration
- ➖ May require coordinating with Onova lifecycle expectations

</details>

**Recommendation:** The overall approach (group settings into General/ExchangeRates and pass General settings into UpdateService) is reasonable and keeps update gating centralized. Consider adjusting the design so the manual ribbon action is not blocked by the ‘check on start’ toggle (i.e., treat it as automation-only), and consider adding a lightweight settings schema migration/version field to reduce resets when older JSON is encountered.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (5)</summary>

<blockquote>
<details>
<summary><strong>MainWindow.xaml</strong> <code>Add ribbon button to manually check for updates</code> <code>+10/-1</code></summary>

<br/>

>Add ribbon button to manually check for updates
>
><pre>
>• Adds a General ribbon group with a “Check for Updates” button wired to CheckForUpdateCommand with a boolean command parameter. Introduces a boolean resource for CommandParameter binding.
></pre>
>
><a href='https://github.com/vov4uk/Financier.Desktop/pull/27/files#diff-22a860482b8560b14e0a90a8e1010a1e634977b023a7525e1bf4877489f84a70'>src/Financier.Desktop/MainWindow.xaml</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>MainWindow.xaml.cs</strong> <code>Load AppSettings and trigger optional update check on startup</code> <code>+7/-3</code></summary>

<br/>

>Load AppSettings and trigger optional update check on startup
>
><pre>
>• Switches from ExchangeRatesSettings to AppSettings and initializes UpdateService without an injected settings DTO. After opening a backup, triggers exchange rate refresh and runs CheckForUpdateCommand with a false parameter (suppressing ‘latest’ messaging).
></pre>
>
><a href='https://github.com/vov4uk/Financier.Desktop/pull/27/files#diff-d8a3da4e68987be52329f89201c383b3e4159682b484f47c75577bbef3f2fe8f'>src/Financier.Desktop/MainWindow.xaml.cs</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>MainWindowVM.cs</strong> <code>Refactor settings persistence and update-check workflow</code> <code>+78/-62</code></summary>

<br/>

>Refactor settings persistence and update-check workflow
>
><pre>
>• Renames persisted settings property to AppSettings and updates all exchange-rate logic to use nested ExchangeRates settings. Adds safer settings deserialization with reset-on-corruption behavior and extends update flow to prompt for restart and pass General settings into UpdateService methods.
></pre>
>
><a href='https://github.com/vov4uk/Financier.Desktop/pull/27/files#diff-b1aff47b50b12b96573a67923c09864b95849e3248884352af5d8d07da0ef5e2'>src/Financier.Desktop/MainWindowVM.cs</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>SettingsControl.xaml</strong> <code>Expose “check for updates on start” in Settings dialog</code> <code>+9/-2</code></summary>

<br/>

>Expose “check for updates on start” in Settings dialog
>
><pre>
>• Adds a new General tab with a checkbox bound to Entity.General.CheckForUpdatesOnStart. Updates exchange-rate bindings to use Entity.ExchangeRates.* properties.
></pre>
>
><a href='https://github.com/vov4uk/Financier.Desktop/pull/27/files#diff-106d30c8bfbca583c604deeb1e40fb910a885e7c9ac361ab2d0b08583a40cc12'>src/Financier.Desktop/Pages/Dialogs/SettingsControl.xaml</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>UpdateService.cs</strong> <code>Gate update operations on General.CheckForUpdatesOnStart</code> <code>+7/-7</code></summary>

<br/>

>Gate update operations on General.CheckForUpdatesOnStart
>
><pre>
>• Removes constructor settings injection and changes Check/Prepare/Finalize update methods to accept SettingsGeneralDTO. Uses CheckForUpdatesOnStart to allow/deny update operations.
></pre>
>
><a href='https://github.com/vov4uk/Financier.Desktop/pull/27/files#diff-f710d7968c83fbf2cf7312005f82921b9ace7011bb371d50d23920b6ba3dfaf7'>src/Financier.Desktop/Services/UpdateService.cs</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Refactor</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>SettingsDTO.cs</strong> <code>Restructure settings into General and ExchangeRates sections</code> <code>+32/-9</code></summary>

<br/>

>Restructure settings into General and ExchangeRates sections
>
><pre>
>• Introduces SettingsGeneralDTO and SettingsExchangeRates and nests them under SettingsDTO. Renames exchange-rate fields (Provider, UpdateOnStart) and adds CheckForUpdatesOnStart under General.
></pre>
>
><a href='https://github.com/vov4uk/Financier.Desktop/pull/27/files#diff-c9d205201cb8c7770ec7543b0fa1221c9a74b0e6e8bf422a0b7006eba5faacc8'>src/Financier.Desktop/Data/SettingsDTO.cs</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>SettingsVM.cs</strong> <code>Update SettingsVM to use nested ExchangeRates properties</code> <code>+8/-8</code></summary>

<br/>

>Update SettingsVM to use nested ExchangeRates properties
>
><pre>
>• Updates provider selection and save logic to read/write Entity.ExchangeRates.Provider and clear Entity.ExchangeRates.OpenExchangeRatesProviderAppId as appropriate.
></pre>
>
><a href='https://github.com/vov4uk/Financier.Desktop/pull/27/files#diff-43d7d0ae513583a8336644ef407b42d1539ce5c344144865fa38f4f89c7cca46'>src/Financier.Desktop/Pages/Dialogs/SettingsVM.cs</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Other</strong> (3)</summary>

<blockquote>
<details>
<summary><strong>Directory.Build.props</strong> <code>Bump application version</code> <code>+1/-1</code></summary>

<br/>

>Bump application version
>
><pre>
>• Updates the project Version from a dev suffix to a numbered release version.
></pre>
>
><a href='https://github.com/vov4uk/Financier.Desktop/pull/27/files#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16e'>Directory.Build.props</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>Directory.Packages.props</strong> <code>Update SonarAnalyzer.CSharp dependency</code> <code>+1/-1</code></summary>

<br/>

>Update SonarAnalyzer.CSharp dependency
>
><pre>
>• Bumps SonarAnalyzer.CSharp from 10.26.0.140279 to 10.27.0.140913.
></pre>
>
><a href='https://github.com/vov4uk/Financier.Desktop/pull/27/files#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156'>Directory.Packages.props</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>Settings.Designer.cs</strong> <code>Rename user setting from ExchangeRatesSettings to AppSettings</code> <code>+3/-3</code></summary>

<br/>

>Rename user setting from ExchangeRatesSettings to AppSettings
>
><pre>
>• Renames the user-scoped settings property to AppSettings, matching the new combined settings JSON storage.
></pre>
>
><a href='https://github.com/vov4uk/Financier.Desktop/pull/27/files#diff-233fde5c88034d3f551143eaa53a73f236f8ccf4c855e50419d1d17a065e97ac'>src/Financier.Desktop/Properties/Settings.Designer.cs</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>